### PR TITLE
Do not keep CAP_SYS_PTRACE privilege

### DIFF
--- a/rtkit-daemon.c
+++ b/rtkit-daemon.c
@@ -1775,8 +1775,7 @@ static int drop_privileges(void) {
         if (do_drop_privileges) {
                 static const cap_value_t cap_values[] = {
                         CAP_SYS_NICE,             /* Needed for obvious reasons */
-                        CAP_DAC_READ_SEARCH,      /* Needed so that we can verify resource limits */
-                        CAP_SYS_PTRACE            /* Needed so that we can read /proc/$$/exe. Linux is weird. */
+                        CAP_DAC_READ_SEARCH      /* Needed so that we can verify resource limits */
                 };
 
                 cap_value_t c, m;

--- a/rtkit-daemon.service.in
+++ b/rtkit-daemon.service.in
@@ -23,7 +23,7 @@ ExecStart=@LIBEXECDIR@/rtkit-daemon
 Type=dbus
 BusName=org.freedesktop.RealtimeKit1
 NotifyAccess=main
-CapabilityBoundingSet=CAP_SYS_NICE CAP_DAC_READ_SEARCH CAP_SYS_PTRACE CAP_SYS_CHROOT CAP_SETGID CAP_SETUID
+CapabilityBoundingSet=CAP_SYS_NICE CAP_DAC_READ_SEARCH CAP_SYS_CHROOT CAP_SETGID CAP_SETUID
 PrivateNetwork=yes
 
 [Install]


### PR DESCRIPTION
Kees Cook writes:

  CAP_SYS_PTRACE is extremely powerful, and seems to only be used for
  debugging (reporting which executable was made RT).

It seems thus safer to drop the privilege.