### PR TITLE
Fix readme

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ NOTES:
         resource limits and chroot() to minimize its security impact.
 
         RealtimeKit probably has little use in embedded or server use
-        cases, use RLIMIT_RTPRIO tehre instead.
+        cases, use RLIMIT_RTPRIO there instead.
 
 WHY:
         If processes that have real-time scheduling privileges enter a
@@ -170,7 +170,7 @@ DAEMON:
         will be delayed a bit.
 
         --rttime-usec-max= may be used to control which RLIMIT_RTTIME
-        value clients need to have chosen at minumum before they may
+        value clients need to have chosen at minimum before they may
         acquire RT scheduling through RealtimeKit.
 
         --users-max= specifies how many users may acquire RT

--- a/README
+++ b/README
@@ -76,12 +76,21 @@ CLIENTS:
                 void MakeThreadHighPriority(u64 thread_id, s32 priority);
 
         The thread IDs need to be passed as kernel tids as returned by
-        gettid(), not a pthread_t! Only threads belonging to the
-        calling process can be made realtime/high priority. (Please
+        gettid(), not a pthread_t!  (Please
         note that gettid() is not available in glibc, you need to
         implement that manually using syscall(). Consult the reference
         client implementation for details.)
+        
+        It is possible to promote thread in process to realtime/high
+        priority from another process, that will make the DBUS call,
+        using:
+        
+                void MakeThreadRealtimeWithPID(u64 process, u64 thread_id, u32 priority);
 
+                void MakeThreadHighPriorityWithPID(u64 process, u64 thread_id, s32 priority);
+
+        where process is the PID of the process that has thread thread_id.
+        
         A BSD-licensed reference implementation of the client is
         available in rtkit.[ch] as part of the package. You may copy
         this into your sources if you wish. However given how simple


### PR DESCRIPTION
Two small documentation patches, one with just typos, and one that fixes something wrong.