### PR TITLE
Fix rtkit-daemon dependency on xml-introspection.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -97,6 +97,9 @@ rtkit-daemon.service: rtkit-daemon.service.in
 xml-introspection.h: org.freedesktop.RealtimeKit1.xml
 	$(AM_V_GEN)$(XXD) -i < $< > $@
 
+BUILT_SOURCES = \
+	xml-introspection.h
+
 man8_MANS = rtkitctl.8
 
 EXTRA_DIST += \


### PR DESCRIPTION
Currently, rtkit-daemon.c may be compiled before xml-introspection.h
has been generated. Add the header to BUILT_SOURCES so that it is
generated before any other targets are processed.