### PR TITLE
Start rtkit-daemon service in the multi-user.target

### DIFF
--- a/rtkit-daemon.service.in
+++ b/rtkit-daemon.service.in
@@ -27,4 +27,4 @@ CapabilityBoundingSet=CAP_SYS_NICE CAP_DAC_READ_SEARCH CAP_SYS_CHROOT CAP_SETGID
 PrivateNetwork=yes
 
 [Install]
-WantedBy=graphical.target
+WantedBy=multi-user.target


### PR DESCRIPTION
Start rtkit-daemon in the multi-user.target by default. This allows
it to work out of the box on a headless system as well as supporting
a graphical.target capable system that's been limited to the
multi-user.target.