### PR TITLE
Make it possible not to link against libsystemd

### DIFF
--- a/README
+++ b/README
@@ -224,4 +224,6 @@ REQUIREMENTS:
         Linux kernel >= 2.6.31
         D-Bus
         PolicyKit >= 0.92
-        libsystemd
+
+OPTIONAL DEPENDENCIES:
+        libsystemd - to let rtkit talk to systemd using the sd-daemon API

--- a/config.h.meson
+++ b/config.h.meson
@@ -3,4 +3,6 @@
 
 #mesondefine PACKAGE_VERSION
 
+#mesondefine HAVE_LIBSYSTEMD
+
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,18 @@ AC_SEARCH_LIBS([mq_open], [rt])
 AC_SEARCH_LIBS([cap_init], [cap])
 
 PKG_CHECK_MODULES(DBUS, dbus-1)
-PKG_CHECK_MODULES(LIBSYSTEMD, libsystemd)
+
+AC_ARG_ENABLE([libsystemd],
+	AS_HELP_STRING([--enable-libsystemd], [use the libsystemd sd-daemon API to communicate with systemd (default: automatic)]))
+AS_IF([test "x${enable_libsystemd}" != "xno"],
+	[PKG_CHECK_MODULES(LIBSYSTEMD, libsystemd, [have_libsystemd=yes], [have_libsystemd=no])],
+	[have_libsystemd=no])
+AS_IF([test "x${have_libsystemd}" = "xyes"],
+	[AC_DEFINE([HAVE_LIBSYSTEMD], [1], [Define to 1 if you have libsystemd and its header files])],
+	[AS_IF([test "x${enable_libsystemd}" = "xyes"],
+		[AC_MSG_ERROR([sd-daemon support requested but libsystemd not found])
+	])
+])
 
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
@@ -148,4 +159,5 @@ echo "
     Compiler:               ${CC}
     CFLAGS:                 ${CFLAGS}
     systemd unit directory: ${systemdsystemunitdir}
+    use sd-daemon API:      ${have_libsystemd}
 "

--- a/meson.build
+++ b/meson.build
@@ -17,7 +17,7 @@ xxd = find_program('xxd')
 
 dbus_dep = dependency('dbus-1')
 libcap_dep = dependency('libcap')
-libsystemd_dep = dependency('libsystemd')
+libsystemd_dep = dependency('libsystemd', required: get_option('libsystemd'))
 polkit_dep = dependency('polkit-gobject-1', required: false)
 systemd_dep = dependency('systemd', required: false)
 thread_dep = dependency('threads')
@@ -72,6 +72,7 @@ endif
 config = configuration_data()
 config.set('LIBEXECDIR', get_option('prefix') / libexecdir)
 config.set_quoted('PACKAGE_VERSION', meson.project_version())
+config.set('HAVE_LIBSYSTEMD', libsystemd_dep.found())
 
 config_h = configure_file(
         input: 'config.h.meson',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,6 +17,12 @@ option(
         description: 'Directory for D-Bus system services',
 )
 option(
+        'libsystemd',
+        type: 'feature',
+        value: 'auto',
+        description: 'Use the libsystemd sd-daemon API to communicate with systemd'
+)
+option(
         'polkit_actiondir',
         type: 'string',
         value: '',

--- a/rtkit-daemon.c
+++ b/rtkit-daemon.c
@@ -50,7 +50,10 @@
 #include <dirent.h>
 #include <syslog.h>
 #include <grp.h>
+
+#ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
+#endif
 
 #include "rtkit.h"
 
@@ -1434,11 +1437,13 @@ static DBusHandlerResult dbus_handler(DBusConnection *c, DBusMessage *m, void *u
                 n_total_processes,
                 n_users);
 
+#ifdef HAVE_LIBSYSTEMD
         sd_notifyf(0,
                    "STATUS=Supervising %u threads of %u processes of %u users.",
                    n_total_threads,
                    n_total_processes,
                    n_users);
+#endif
 
 finish:
         if (r) {
@@ -2306,7 +2311,9 @@ int main(int argc, char *argv[]) {
 
         syslog(LOG_DEBUG, "Running.\n");
 
+#ifdef HAVE_LIBSYSTEMD
         sd_notify(0, "STATUS=Running.");
+#endif
 
         dbus_connection_set_exit_on_disconnect(bus, FALSE);
 


### PR DESCRIPTION
This PR adds a configure option --disable-systemd-integration, which allows anyone who does not wish rtkit to use the sd-daemon API (_e.g._ Gentoo users who have chosen to stick with OpenRC as their init system) not to link it against libsystemd.

rtkit is very important _e.g._ for having PulseAudio sound work properly even under high system load and while I personally am a huge fan of systemd, I see no reason to deny access to newer rtkit versions to users of other init systems.
