### PR TITLE
meson: Install rtkitctl to sbin

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -115,6 +115,7 @@ executable(
         'rtkitctl',
         'rtkitctl.c', 'rtkit.h', config_h,
         install: true,
+        install_dir: get_option('sbindir'),
         dependencies: [dbus_dep],
 )
 


### PR DESCRIPTION
That is the path previously used in the autotools system