### PR TITLE
Add Graceful System-Suspend Support

### DIFF
--- a/README
+++ b/README
@@ -80,17 +80,17 @@ CLIENTS:
         note that gettid() is not available in glibc, you need to
         implement that manually using syscall(). Consult the reference
         client implementation for details.)
-        
+
         It is possible to promote thread in process to realtime/high
         priority from another process, that will make the DBUS call,
         using:
-        
+
                 void MakeThreadRealtimeWithPID(u64 process, u64 thread_id, u32 priority);
 
                 void MakeThreadHighPriorityWithPID(u64 process, u64 thread_id, s32 priority);
 
         where process is the PID of the process that has thread thread_id.
-        
+
         A BSD-licensed reference implementation of the client is
         available in rtkit.[ch] as part of the package. You may copy
         this into your sources if you wish. However given how simple
@@ -227,3 +227,4 @@ REQUIREMENTS:
 
 OPTIONAL DEPENDENCIES:
         libsystemd - to let rtkit talk to systemd using the sd-daemon API
+        logind (runtime) - to gracefully handle system-suspend

--- a/org.freedesktop.RealtimeKit1.conf
+++ b/org.freedesktop.RealtimeKit1.conf
@@ -22,6 +22,10 @@
                                         send_interface="org.freedesktop.RealtimeKit1" send_member="ResetKnown"/>
                 <deny send_destination="org.freedesktop.RealtimeKit1"
                                         send_interface="org.freedesktop.RealtimeKit1" send_member="ResetAll"/>
+                <deny send_destination="org.freedesktop.RealtimeKit1"
+                                        send_interface="org.freedesktop.RealtimeKit1" send_member="Suspend"/>
+                <deny send_destination="org.freedesktop.RealtimeKit1"
+                                        send_interface="org.freedesktop.RealtimeKit1" send_member="Resume"/>
         </policy>
 
         <policy user="root">

--- a/org.freedesktop.RealtimeKit1.xml
+++ b/org.freedesktop.RealtimeKit1.xml
@@ -15,12 +15,12 @@
                 </method>
                 <method name="MakeThreadHighPriority">
                         <arg name="thread" type="t" direction="in"/>
-                        <arg name="priority" type="i" direction="in"/>
+                        <arg name="nice_level" type="i" direction="in"/>
                 </method>
                 <method name="MakeThreadHighPriorityWithPID">
                         <arg name="process" type="t" direction="in"/>
                         <arg name="thread" type="t" direction="in"/>
-                        <arg name="priority" type="i" direction="in"/>
+                        <arg name="nice_level" type="i" direction="in"/>
                 </method>
                 <method name="ResetKnown"/>
                 <method name="ResetAll"/>

--- a/org.freedesktop.RealtimeKit1.xml
+++ b/org.freedesktop.RealtimeKit1.xml
@@ -24,6 +24,8 @@
                 </method>
                 <method name="ResetKnown"/>
                 <method name="ResetAll"/>
+                <method name="Suspend"/>
+                <method name="Resume"/>
                 <method name="Exit"/>
                 <property name="RTTimeUSecMax" type="x" access="read"/>
                 <property name="MaxRealtimePriority" type="i" access="read"/>

--- a/rtkit-daemon.c
+++ b/rtkit-daemon.c
@@ -1518,6 +1518,7 @@ static DBusHandlerResult dbus_handler(DBusConnection *c, DBusMessage *m, void *u
                                 DBUS_ERROR_UNKNOWN_PROPERTY,
                                 "Unknown interface %s",
                                 interface));
+                goto finish;
 
         } else if (dbus_message_is_method_call(m, "org.freedesktop.DBus.Introspectable", "Introspect")) {
                 const char *xml = introspect_xml;
@@ -1527,6 +1528,7 @@ static DBusHandlerResult dbus_handler(DBusConnection *c, DBusMessage *m, void *u
                                           r,
                                           DBUS_TYPE_STRING, &xml,
                                           DBUS_TYPE_INVALID));
+                goto finish;
         } else
                 return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 

--- a/rtkit-daemon.c
+++ b/rtkit-daemon.c
@@ -1101,10 +1101,7 @@ static int logind_inhibit_sleep(DBusConnection *connection) {
                         DBUS_TYPE_UNIX_FD, &fd,
                         DBUS_TYPE_INVALID)) {
                 syslog(LOG_DEBUG, "Failed to parse inhibit sleep reply: %s", error.message);
-                goto finish;
         }
-
-        syslog(LOG_INFO, "Handling system-suspend using logind.\n");
 
 finish:
         if (r)
@@ -1663,6 +1660,8 @@ static void setup_logind(DBusConnection *c) {
         }
 
         assert_se(dbus_connection_add_filter(c, dbus_logind_handler, NULL, NULL));
+
+        syslog(LOG_INFO, "Handling system-suspend using logind.\n");
 }
 
 static int setup_dbus(DBusConnection **c) {

--- a/rtkit-daemon.c
+++ b/rtkit-daemon.c
@@ -196,6 +196,9 @@ static int quit_fd = -1, canary_fd = -1;
 static pthread_t canary_thread_id = 0, watchdog_thread_id = 0;
 static volatile uint32_t refuse_until = 0;
 
+static int start_canary(void);
+static void stop_canary(void);
+
 static const char *get_proc_path(void) {
         /* Useful for chroot environments */
 
@@ -969,6 +972,14 @@ static int reset_all(void) {
         return 0;
 }
 
+static void suspend(void) {
+        // TODO
+}
+
+static void resume(void) {
+        // TODO
+}
+
 /* This mimics dbus_bus_get_unix_user() */
 static unsigned long get_unix_process_id(
                 DBusConnection *connection,
@@ -1379,6 +1390,16 @@ static DBusHandlerResult dbus_handler(DBusConnection *c, DBusMessage *m, void *u
 
                 reset_known();
                 user_gc();
+                assert_se(r = dbus_message_new_method_return(m));
+
+        } else if (dbus_message_is_method_call(m, "org.freedesktop.RealtimeKit1", "Suspend")) {
+
+                suspend();
+                assert_se(r = dbus_message_new_method_return(m));
+
+        } else if (dbus_message_is_method_call(m, "org.freedesktop.RealtimeKit1", "Resume")) {
+
+                resume();
                 assert_se(r = dbus_message_new_method_return(m));
 
         } else if (dbus_message_is_method_call(m, "org.freedesktop.RealtimeKit1", "Exit")) {

--- a/rtkitctl.8
+++ b/rtkitctl.8
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH RTKITCTL 8 "July 1, 2009"
+.TH RTKITCTL 8 "October 16, 2023"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -36,6 +36,12 @@ Reset real-time status of known threads.
 .TP
 .B \-\-reset\-all
 Reset real-time status of all threads.
+.TP
+.B \-\-suspend
+Temporarily reset real-time status of known threads.
+.TP
+.B \-\-resume
+Restore real-time status of known threads temporarily reset by suspend.
 .TP
 .B \-\-start
 Start RealtimeKit if it is not running already.

--- a/rtkitctl.c
+++ b/rtkitctl.c
@@ -46,7 +46,9 @@ static void show_help(const char *exe) {
                "      --reset-known  Reset real-time status of known threads\n"
                "      --reset-all    Reset real-time status of all threads\n"
                "      --start        Start RealtimeKit if it is not running already\n"
-               "  -k, --exit         Terminate running RealtimeKit daemon\n",
+               "  -k, --exit         Terminate running RealtimeKit daemon\n"
+               "      --suspend      Suspend real-time status of known threads and reject new requests\n"
+               "      --resume       Resume real-time status of known threads and allow new requests\n",
                exe);
 }
 
@@ -58,6 +60,8 @@ int main (int argc, char*argv[]) {
                 ARG_EXIT,
                 ARG_RESET_KNOWN,
                 ARG_RESET_ALL,
+                ARG_SUSPEND,
+                ARG_RESUME,
         };
 
         static const struct option long_options[] = {
@@ -67,6 +71,8 @@ int main (int argc, char*argv[]) {
                 { "exit",        no_argument, 0, ARG_EXIT },
                 { "reset-known", no_argument, 0, ARG_RESET_KNOWN },
                 { "reset-all",   no_argument, 0, ARG_RESET_ALL },
+                { "suspend",     no_argument, 0, ARG_SUSPEND },
+                { "resume",      no_argument, 0, ARG_RESUME },
                 { NULL, 0, 0, 0}
         };
 
@@ -75,6 +81,8 @@ int main (int argc, char*argv[]) {
                 OPERATION_EXIT,
                 OPERATION_RESET_KNOWN,
                 OPERATION_RESET_ALL,
+                OPERATION_SUSPEND,
+                OPERATION_RESUME,
                 _OPERATION_MAX
         };
 
@@ -82,7 +90,9 @@ int main (int argc, char*argv[]) {
                 [OPERATION_START] = "StartServiceByName",
                 [OPERATION_EXIT] = "Exit",
                 [OPERATION_RESET_KNOWN] = "ResetKnown",
-                [OPERATION_RESET_ALL] = "ResetAll"
+                [OPERATION_RESET_ALL] = "ResetAll",
+                [OPERATION_SUSPEND] = "Suspend",
+                [OPERATION_RESUME] = "Resume"
         };
 
         DBusError error;
@@ -123,6 +133,14 @@ int main (int argc, char*argv[]) {
 
                         case ARG_RESET_ALL:
                                 operation = OPERATION_RESET_ALL;
+                                break;
+
+                        case ARG_SUSPEND:
+                                operation = OPERATION_SUSPEND;
+                                break;
+
+                        case ARG_RESUME:
+                                operation = OPERATION_RESUME;
                                 break;
 
                         case '?':


### PR DESCRIPTION
This PR address the issue of canary false-positives cased by system-suspend by adding new public methods of "Suspend()" and "Resume()", as well as optionally connecting them to `logind` system-sleep handling.

## The Bug

During a system suspend-resume (sleep) cycle, the canary thread often experiences a time jump which causes a starvation false-positive. `rtkit` takes action and demotes the realtime/high priority of all known threads.

Long running realtime processes (Pipewire, Pulseaudio) generally only request realtime/high priority once. If a system goes to sleep, the realtime/high priority scheduling is lost until these long-running processes are next started, after logout and login. As users generally suspend their machines more often than logging in, rtkit is basically non-functional for these processes, arguably the most important processes to use rtkit.

Even non-long-running processes may have lifecycles which span system suspend-resume cycles, and so operate in a degraded way for users.

### See
- https://bugzilla.redhat.com/show_bug.cgi?id=688282
- https://github.com/heftig/rtkit/issues/13

## Why

With the view that the primary bug this change seeks to address is the canary false positives, it would seem to be far simpler to only start and stop use of the the canary during suspend. However, doing so would degrade security for a controllable window. From a security perspective, one might as well just disable the canary altogether. To safely disable the canary, we need to first demote all threads.

## Suspend/Resume Operation

Two new admin operations are added to rtkit.

- Suspend: `org.freedesktop.RealtimeKit1.Suspend()`, `rtkitctl --suspend`
- Resume. `org.freedesktop.RealtimeKit1.Resume()`, `rtkitctl --resume`

These temporarily demote and restore managed thread priorities, as well as stop and start the canary.

On `Suspend()`, all managed threads are demoted, and the canary stopped.

While suspended, new realtime/high priority requests are rejected. Managed thread states are still garbage if a thread exists, but are retained otherwise.

On `Resume()` the canary is restarted, and all managed threads are re-promoted. Current user burst limit timeouts are restarted, and the re-promotion of threads counts toward burst limiting, but the burst limit is not enforced on the re-promotion.  

Calling `ResetKnown()` or `ResetAll()` while suspended removes all managed threads which lack realtime/high-priority, leaving no threads to re-promote later.

Calling either `Suspend()` and `Resume()` multiple times in a row is fine, but only the first call has an effect.

## Security Considerations

`Suspend()` and `Resume()` are only available to admin callers, preventing abuse. Notwithstanding, if a malicious user was able to call suspend and resume at will, they still could not circumvent the count or burst limits. No new threads promotions can be created when suspended. Further, while the user burst limit is not enforced on resume, it is still updated, and the burst timeout restarted.

It may be safe to allow for new realtime/high priority grants while in suspended mode to take effect upon resume, but this is an unlikely case, so it's easier to just refuse.

## `logind` Integration

This change also adds an optional runtime integration with logind's inhibitor locks for handling system-suspend.

If the `logind` dbus service is running and accessible, `rtkit` will register a "delay sleep inhibitor", and listen for signals from logind about when the system is going to sleep or having just woken up. Using the sleep inhibitor, logind will wait for rtkit to perform it's `Suspend()` operation before letting the system suspend. On system resume, logind will again notify rtkit, which will perform `Resume()` and register a new inhibitor.

See https://www.freedesktop.org/wiki/Software/systemd/inhibit/

## Alternate Integrations

No alternate automatic system-suspend integration is provided, but `rtkitctl --suspend` and `rtkitctl --resume` should make this task easy.

## Other Changes

- Rename `priority` (dynamic) to `nice_level` inside of `process_set_high_priority()`. Helps differentiate it from `priority` (static) as used by `process_set_realtime()`. Also, it's called `nice_level` everywhere else in the code.

- Reduce log spam by not printing a message for every handled dbus message, as that includes dbus introspection and properties related messages. Some programs (Firefox in my case) get rtkit properties more frequently than I would think necessary.